### PR TITLE
Added MTU checks + reduced MTU size cluster option

### DIFF
--- a/tasks/create_cluster.yml
+++ b/tasks/create_cluster.yml
@@ -4,18 +4,30 @@
 
 # -----------------------------------------------------
 # Verify the node count is a valid settings (1,2,4,6,8)
+# Verify MTU Size
 # -----------------------------------------------------
 
-- name: Fail check
+- name: Fail check - node count
   fail:
     msg: "INVALID NODE COUNT - Must be 1,2,4,6 or 8.  Node Count currently set to {{ node_count }}"
   when: node_count not in [1,2,4,6,8]
 
+- name: Fail check - MTU Size too small
+  fail:
+    msg: "Unsupported MTU Size - less than 7500. Current MTU Size is {{ net_mtu }}"
+  when: (node_count > 1 and net_mtu < 7500)
+
+- name: Fail check - MTU Size too large
+  fail:
+    msg: "Unsupported MTU Size - greater than 9000. Current MTU Size is {{ net_mtu }}"
+  when: (node_count > 1 and net_mtu > 9000)
+
 # -----------------------------------------------------------------
 # Create the initial cluster template for the configure_node* tasks
+# One task for single node and one task for multi-node  due to MTU size
 # -----------------------------------------------------------------
 
-- name: .....creating cluster
+- name: .....creating cluster - single node
 
   uri:
     url: "{{ deploy_api_url }}/clusters?node_count={{ node_count }}"
@@ -37,5 +49,31 @@
     password: "{{ deploy_pwd }}"
     status_code: 201
     validate_certs: False
+  when: node_count == 1
+
+- name: .....creating cluster - multi-node
+
+  uri:
+    url: "{{ deploy_api_url }}/clusters?node_count={{ node_count }}"
+    method: POST
+    headers:
+      Content-Type: "application/json"
+    body:
+      name: "{{ cluster_name }}"
+      ontap_image_version: "{{ cluster_ontap_image }}"
+      gateway: "{{ cluster_gateway }}"
+      ip: "{{ cluster_ip }}"
+      netmask: "{{ cluster_netmask }}"
+      mtu: "{{ net_mtu }}"
+      ntp_servers: "{{ cluster_ntp }}"
+      dns_info:
+        dns_ips: "{{ cluster_dns_ips }}"
+        domains: "{{ cluster_dns_domains }}"
+    body_format: json
+    user: "{{ deploy_login }}"
+    password: "{{ deploy_pwd }}"
+    status_code: 201
+    validate_certs: False
+  when: node_count > 1 
 
   register: cluster_create_response


### PR DESCRIPTION
- 2 new variable checks created  (for unsupported MTU sizes too small < 7500 bytes or too large > 9000)
- Duplicated existing cluster install task and added a conditional to each (one for single node clusters without MTU option in the body and one for multi-node clusters